### PR TITLE
Fix README.me about command option for run_assistant_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ make run_assistant
 7. Start one of the `run_assistant` samples:
 
 ```bash
-./run_assistant_file --input ./resources/weather_in_mountain_view.raw --audio_output ./response.wav --credentials ./credentials.json
+./run_assistant_file --input ./resources/weather_in_mountain_view.raw --output ./response.wav --credentials ./credentials.json
 aplay ./response.wav --rate=16000 --format=S16_LE
 ```
 


### PR DESCRIPTION
Small fix in README.md with only 1 line change.

It seems that option string for "run_assistant_file" had been changed from "--audio_output" to "--output". This fix will change corresponding description in README.md.

I tried to run this on Raspberry Pi 3 and setup as README.md said, worked fine for me. Very useful and precise document for me, thanks

Best Regards,

Yuji Ogiwara
 