### PR TITLE
Cleanup run_assistant_file dependencies.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,6 @@ ASSISTANT_AUDIO_O = $(CORE_SRCS:.cc=.o) \
                     $(AUDIO_INPUT_FILE_SRCS:.cc=.o) \
                     $(ASSISTANT_AUDIO_SRCS:.cc=.o)
 ASSISTANT_FILE_O  = $(CORE_SRCS:.cc=.o) \
-                    $(AUDIO_SRCS:.cc=.o) \
                     $(AUDIO_INPUT_FILE_SRCS:.cc=.o) \
                     $(ASSISTANT_FILE_SRCS:.cc=.o)
 ASSISTANT_TEXT_O  = $(CORE_SRCS:.cc=.o) \


### PR DESCRIPTION
AUDIO_SRCS are not needed to build run_assistant_file.