### PR TITLE
Apply clang-format with Google's style.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: Google
+Language: Cpp
+Standard: Cpp11

--- a/src/audio_input.h
+++ b/src/audio_input.h
@@ -18,11 +18,11 @@ limitations under the License.
 #define AUDIO_INPUT_H
 
 #include <functional>
+#include <iostream>
 #include <memory>
 #include <mutex>
 #include <thread>
 #include <vector>
-#include <iostream>
 
 // Base class for audio input. Input data should be mono, s16_le, 16000kz.
 // This class uses a separate thread to send audio data to listeners.
@@ -33,7 +33,7 @@ class AudioInput {
   // Listeners might be called in different thread.
   void AddDataListener(
       std::function<void(std::shared_ptr<std::vector<unsigned char>>)>
-      listener) {
+          listener) {
     data_listeners_.push_back(listener);
   }
   void AddStopListener(std::function<void()> listener) {

--- a/src/audio_input_alsa.cc
+++ b/src/audio_input_alsa.cc
@@ -24,68 +24,80 @@ std::unique_ptr<std::thread> AudioInputALSA::GetBackgroundThread() {
   return std::unique_ptr<std::thread>(new std::thread([this]() {
     // Initialize.
     snd_pcm_t* pcm_handle;
-    int pcm_open_ret = snd_pcm_open(&pcm_handle, "default", SND_PCM_STREAM_CAPTURE, 0);
+    int pcm_open_ret =
+        snd_pcm_open(&pcm_handle, "default", SND_PCM_STREAM_CAPTURE, 0);
     if (pcm_open_ret < 0) {
-      std::cerr << "AudioInputALSA snd_pcm_open returned " << pcm_open_ret << std::endl;
+      std::cerr << "AudioInputALSA snd_pcm_open returned " << pcm_open_ret
+                << std::endl;
       return;
     }
+
     int pcm_nonblock_ret = snd_pcm_nonblock(pcm_handle, SND_PCM_NONBLOCK);
     if (pcm_nonblock_ret < 0) {
-      std::cerr << "AudioInputALSA snd_pcm_nonblock returned " << pcm_nonblock_ret << std::endl;
+      std::cerr << "AudioInputALSA snd_pcm_nonblock returned "
+                << pcm_nonblock_ret << std::endl;
       return;
     }
+
     snd_pcm_hw_params_t* pcm_params;
     int malloc_param_ret = snd_pcm_hw_params_malloc(&pcm_params);
     if (malloc_param_ret < 0) {
-      std::cerr << "AudioInputALSA snd_pcm_hw_params_malloc returned " << malloc_param_ret
-          << std::endl;
+      std::cerr << "AudioInputALSA snd_pcm_hw_params_malloc returned "
+                << malloc_param_ret << std::endl;
       return;
     }
+
     snd_pcm_hw_params_any(pcm_handle, pcm_params);
-    int set_param_ret =
-        snd_pcm_hw_params_set_access(pcm_handle, pcm_params, SND_PCM_ACCESS_RW_INTERLEAVED);
+    int set_param_ret = snd_pcm_hw_params_set_access(
+        pcm_handle, pcm_params, SND_PCM_ACCESS_RW_INTERLEAVED);
     if (set_param_ret < 0) {
-      std::cerr << "AudioInputALSA snd_pcm_hw_params_set_access returned " << set_param_ret
-          << std::endl;
+      std::cerr << "AudioInputALSA snd_pcm_hw_params_set_access returned "
+                << set_param_ret << std::endl;
       return;
     }
-    set_param_ret =
-        snd_pcm_hw_params_set_format(pcm_handle, pcm_params, SND_PCM_FORMAT_S16_LE);
+
+    set_param_ret = snd_pcm_hw_params_set_format(pcm_handle, pcm_params,
+                                                 SND_PCM_FORMAT_S16_LE);
     if (set_param_ret < 0) {
-      std::cerr << "AudioInputALSA snd_pcm_hw_params_set_format returned " << set_param_ret
-          << std::endl;
+      std::cerr << "AudioInputALSA snd_pcm_hw_params_set_format returned "
+                << set_param_ret << std::endl;
       return;
     }
-    set_param_ret =
-        snd_pcm_hw_params_set_channels(pcm_handle, pcm_params, 1);
+
+    set_param_ret = snd_pcm_hw_params_set_channels(pcm_handle, pcm_params, 1);
     if (set_param_ret < 0) {
-      std::cerr << "AudioInputALSA snd_pcm_hw_params_set_channels returned " << set_param_ret
-          << std::endl;
+      std::cerr << "AudioInputALSA snd_pcm_hw_params_set_channels returned "
+                << set_param_ret << std::endl;
       return;
     }
+
     unsigned int rate = 16000;
     set_param_ret =
         snd_pcm_hw_params_set_rate_near(pcm_handle, pcm_params, &rate, nullptr);
     if (set_param_ret < 0) {
-      std::cerr << "AudioInputALSA snd_pcm_hw_params_set_rate_near returned " << set_param_ret
-          << std::endl;
+      std::cerr << "AudioInputALSA snd_pcm_hw_params_set_rate_near returned "
+                << set_param_ret << std::endl;
       return;
     }
+
     set_param_ret = snd_pcm_hw_params(pcm_handle, pcm_params);
     if (set_param_ret < 0) {
-      std::cerr << "AudioInputALSA snd_pcm_hw_params returned " << set_param_ret << std::endl;
+      std::cerr << "AudioInputALSA snd_pcm_hw_params returned " << set_param_ret
+                << std::endl;
       return;
     }
     snd_pcm_hw_params_free(pcm_params);
 
     while (is_running_) {
       std::shared_ptr<std::vector<unsigned char>> audio_data(
-            new std::vector<unsigned char>(kFramesPerPacket * kBytesPerFrame));
-      int pcm_read_ret = snd_pcm_readi(pcm_handle, &(*audio_data.get())[0], kFramesPerPacket);
+          new std::vector<unsigned char>(kFramesPerPacket * kBytesPerFrame));
+      int pcm_read_ret =
+          snd_pcm_readi(pcm_handle, &(*audio_data.get())[0], kFramesPerPacket);
       if (pcm_read_ret == -EAGAIN) {
         std::this_thread::sleep_for(std::chrono::milliseconds(20));
       } else if (pcm_read_ret < 0) {
-        std::cerr << "AudioInputALSA snd_pcm_readi returned " << pcm_read_ret << std::endl;
+        std::cerr << "AudioInputALSA snd_pcm_readi returned " << pcm_read_ret
+                  << std::endl;
         break;
       } else if (pcm_read_ret > 0) {
         audio_data->resize(kBytesPerFrame * pcm_read_ret);

--- a/src/audio_input_file.cc
+++ b/src/audio_input_file.cc
@@ -24,7 +24,8 @@ std::unique_ptr<std::thread> AudioInputFile::GetBackgroundThread() {
     // Initialize.
     std::ifstream file_stream(file_path_);
     if (!file_stream) {
-      std::cerr << "AudioInputFile cannot open file " << file_path_ << std::endl;
+      std::cerr << "AudioInputFile cannot open file " << file_path_
+                << std::endl;
       return;
     }
 

--- a/src/audio_input_file.h
+++ b/src/audio_input_file.h
@@ -18,7 +18,7 @@ limitations under the License.
 
 class AudioInputFile : public AudioInput {
  public:
-  AudioInputFile(const std::string& file_path): file_path_(file_path) {}
+  AudioInputFile(const std::string& file_path) : file_path_(file_path) {}
   ~AudioInputFile() override {}
 
   virtual std::unique_ptr<std::thread> GetBackgroundThread() override;

--- a/src/audio_output_alsa.cc
+++ b/src/audio_output_alsa.cc
@@ -28,78 +28,92 @@ bool AudioOutputALSA::Start() {
   }
 
   snd_pcm_t* pcm_handle;
-  int pcm_open_ret = snd_pcm_open(&pcm_handle, "default", SND_PCM_STREAM_PLAYBACK, 0);
+  int pcm_open_ret =
+      snd_pcm_open(&pcm_handle, "default", SND_PCM_STREAM_PLAYBACK, 0);
   if (pcm_open_ret < 0) {
-    std::cerr << "AudioOutputALSA snd_pcm_open returned " << pcm_open_ret << std::endl;
+    std::cerr << "AudioOutputALSA snd_pcm_open returned " << pcm_open_ret
+              << std::endl;
     return false;
   }
+
   snd_pcm_hw_params_t* pcm_params;
   int malloc_param_ret = snd_pcm_hw_params_malloc(&pcm_params);
   if (malloc_param_ret < 0) {
-    std::cerr << "AudioOutputALSA snd_pcm_hw_params_malloc returned " << malloc_param_ret
-        << std::endl;
+    std::cerr << "AudioOutputALSA snd_pcm_hw_params_malloc returned "
+              << malloc_param_ret << std::endl;
     return false;
   }
+
   snd_pcm_hw_params_any(pcm_handle, pcm_params);
-  int set_param_ret =
-      snd_pcm_hw_params_set_access(pcm_handle, pcm_params, SND_PCM_ACCESS_RW_INTERLEAVED);
+  int set_param_ret = snd_pcm_hw_params_set_access(
+      pcm_handle, pcm_params, SND_PCM_ACCESS_RW_INTERLEAVED);
   if (set_param_ret < 0) {
-    std::cerr << "AudioOutputALSA snd_pcm_hw_params_set_access returned " << set_param_ret
-        << std::endl;
+    std::cerr << "AudioOutputALSA snd_pcm_hw_params_set_access returned "
+              << set_param_ret << std::endl;
     return false;
   }
-  set_param_ret =
-      snd_pcm_hw_params_set_format(pcm_handle, pcm_params, SND_PCM_FORMAT_S16_LE);
+
+  set_param_ret = snd_pcm_hw_params_set_format(pcm_handle, pcm_params,
+                                               SND_PCM_FORMAT_S16_LE);
   if (set_param_ret < 0) {
-    std::cerr << "AudioOutputALSA snd_pcm_hw_params_set_format returned " << set_param_ret
-        << std::endl;
+    std::cerr << "AudioOutputALSA snd_pcm_hw_params_set_format returned "
+              << set_param_ret << std::endl;
     return false;
   }
-  set_param_ret =
-      snd_pcm_hw_params_set_channels(pcm_handle, pcm_params, 1);
+
+  set_param_ret = snd_pcm_hw_params_set_channels(pcm_handle, pcm_params, 1);
   if (set_param_ret < 0) {
-    std::cerr << "AudioOutputALSA snd_pcm_hw_params_set_channels returned " << set_param_ret
-        << std::endl;
+    std::cerr << "AudioOutputALSA snd_pcm_hw_params_set_channels returned "
+              << set_param_ret << std::endl;
     return false;
   }
+
   unsigned int rate = 16000;
   set_param_ret =
       snd_pcm_hw_params_set_rate_near(pcm_handle, pcm_params, &rate, nullptr);
   if (set_param_ret < 0) {
-    std::cerr << "AudioOutputALSA snd_pcm_hw_params_set_rate_near returned " << set_param_ret
-        << std::endl;
+    std::cerr << "AudioOutputALSA snd_pcm_hw_params_set_rate_near returned "
+              << set_param_ret << std::endl;
     return false;
   }
+
   set_param_ret = snd_pcm_hw_params(pcm_handle, pcm_params);
   if (set_param_ret < 0) {
-    std::cerr << "AudioOutputALSA snd_pcm_hw_params returned " << set_param_ret << std::endl;
+    std::cerr << "AudioOutputALSA snd_pcm_hw_params returned " << set_param_ret
+              << std::endl;
     return false;
   }
+
   snd_pcm_hw_params_free(pcm_params);
 
   isRunning = true;
   alsaThread.reset(new std::thread([this, pcm_handle]() {
     while (isRunning) {
       std::unique_lock<std::mutex> lock(audioDataMutex);
+
       while (audioData.size() == 0 && isRunning) {
         audioDataCv.wait_for(lock, std::chrono::milliseconds(100));
       }
+
       if (!isRunning) {
         break;
       }
 
       std::shared_ptr<std::vector<unsigned char>> data = audioData[0];
       audioData.erase(audioData.begin());
-      int frames = data->size() / 2;  // 1 channel, S16LE, so 2 bytes each frame.
+      // 1 channel, S16LE, so 2 bytes each frame.
+      int frames = data->size() / 2;
       int pcm_write_ret = snd_pcm_writei(pcm_handle, &(*data.get())[0], frames);
       if (pcm_write_ret < 0) {
         int pcm_recover_ret = snd_pcm_recover(pcm_handle, pcm_write_ret, 0);
         if (pcm_recover_ret < 0) {
-          std::cerr << "AudioOutputALSA snd_pcm_recover returns " << pcm_recover_ret << std::endl;
+          std::cerr << "AudioOutputALSA snd_pcm_recover returns "
+                    << pcm_recover_ret << std::endl;
           break;
         }
       }
     }
+
     // Wait for all data to be consumed.
     snd_pcm_drain(pcm_handle);
     snd_pcm_close(pcm_handle);

--- a/src/base64_encode.cc
+++ b/src/base64_encode.cc
@@ -16,23 +16,28 @@ limitations under the License.
 
 #include "base64_encode.h"
 
-// https://stackoverflow.com/questions/180947/base64-decode-snippet-in-c by Manuel Martinez
+// https://stackoverflow.com/questions/180947/base64-decode-snippet-in-c by
+// Manuel Martinez
 std::string base64_encode(const std::string &in) {
   std::string out;
 
-  int val=0, valb=-6;
+  int val = 0, valb = -6;
   for (u_char c : in) {
-      val = (val<<8) + c;
-      valb += 8;
-      while (valb>=0) {
-          out.push_back("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"[(val>>valb)&0x3F]);
-          valb-=6;
-      }
+    val = (val << 8) + c;
+    valb += 8;
+    while (valb >= 0) {
+      out.push_back(
+          "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+              [(val >> valb) & 0x3F]);
+      valb -= 6;
+    }
   }
-  if (valb>-6) {
-    out.push_back("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"[((val<<8)>>(valb+8))&0x3F]);
+  if (valb > -6) {
+    out.push_back(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+            [((val << 8) >> (valb + 8)) & 0x3F]);
   }
-  while (out.size()%4) {
+  while (out.size() % 4) {
     out.push_back('=');
   }
   return out;

--- a/src/json_util_test.cc
+++ b/src/json_util_test.cc
@@ -21,9 +21,9 @@ limitations under the License.
 bool check_result(const std::string& input_json,
                   std::unique_ptr<std::string> intended_result) {
   std::unique_ptr<std::string> result = GetCustomResponseOrNull(input_json);
-  return (intended_result == nullptr && result == nullptr)
-      || (intended_result != nullptr && result != nullptr
-          && *intended_result == *result);
+  return (intended_result == nullptr && result == nullptr) ||
+         (intended_result != nullptr && result != nullptr &&
+          *intended_result == *result);
 }
 
 int main() {

--- a/src/run_assistant_audio.cc
+++ b/src/run_assistant_audio.cc
@@ -20,12 +20,11 @@ limitations under the License.
 
 #include <chrono>
 #include <fstream>
+#include <iostream>
 #include <iterator>
+#include <sstream>
 #include <string>
 #include <thread>
-#include <iostream>
-#include <fstream>
-#include <sstream>
 
 #ifdef __linux__
 #define ENABLE_ALSA
@@ -36,8 +35,8 @@ limitations under the License.
 #include "audio_output_alsa.h"
 #endif
 
-#include "google/assistant/embedded/v1alpha2/embedded_assistant.pb.h"
 #include "google/assistant/embedded/v1alpha2/embedded_assistant.grpc.pb.h"
+#include "google/assistant/embedded/v1alpha2/embedded_assistant.pb.h"
 
 #include "assistant_config.h"
 #include "audio_input.h"
@@ -45,13 +44,14 @@ limitations under the License.
 #include "base64_encode.h"
 #include "json_util.h"
 
-using google::assistant::embedded::v1alpha2::EmbeddedAssistant;
 using google::assistant::embedded::v1alpha2::AssistRequest;
 using google::assistant::embedded::v1alpha2::AssistResponse;
+using google::assistant::embedded::v1alpha2::
+    AssistResponse_EventType_END_OF_UTTERANCE;
 using google::assistant::embedded::v1alpha2::AudioInConfig;
 using google::assistant::embedded::v1alpha2::AudioOutConfig;
+using google::assistant::embedded::v1alpha2::EmbeddedAssistant;
 using google::assistant::embedded::v1alpha2::ScreenOutConfig;
-using google::assistant::embedded::v1alpha2::AssistResponse_EventType_END_OF_UTTERANCE;
 
 using grpc::CallCredentials;
 using grpc::Channel;
@@ -79,8 +79,9 @@ std::shared_ptr<Channel> CreateChannel(const std::string& host) {
   auto creds = ::grpc::SslCredentials(ssl_opts);
   std::string server = host + ":443";
   if (verbose) {
-    std::clog << "assistant_sdk CreateCustomChannel(" << server << ", creds, arg)"
-      << std::endl << std::endl;
+    std::clog << "assistant_sdk CreateCustomChannel(" << server
+              << ", creds, arg)" << std::endl
+              << std::endl;
   }
   ::grpc::ChannelArguments channel_args;
   return CreateCustomChannel(server, creds, channel_args);
@@ -91,21 +92,20 @@ void PrintUsage() {
             << "--credentials <credentials_file> "
             << "[--api_endpoint <API endpoint>] "
             << "[--locale <locale>]"
-            << "[--html_out <command to load HTML page>]"
-            << std::endl;
+            << "[--html_out <command to load HTML page>]" << std::endl;
 }
 
-bool GetCommandLineFlags(
-    int argc, char** argv, std::string* credentials_file_path,
-    std::string* api_endpoint, std::string* locale, std::string* html_out_command) {
+bool GetCommandLineFlags(int argc, char** argv,
+                         std::string* credentials_file_path,
+                         std::string* api_endpoint, std::string* locale,
+                         std::string* html_out_command) {
   const struct option long_options[] = {
-    {"credentials", required_argument, nullptr, 'c'},
-    {"api_endpoint",     required_argument, nullptr, 'e'},
-    {"locale",           required_argument, nullptr, 'l'},
-    {"verbose",          no_argument, nullptr, 'v'},
-    {"html_out",         required_argument, nullptr, 'h'},
-    {nullptr, 0, nullptr, 0}
-  };
+      {"credentials", required_argument, nullptr, 'c'},
+      {"api_endpoint", required_argument, nullptr, 'e'},
+      {"locale", required_argument, nullptr, 'l'},
+      {"verbose", no_argument, nullptr, 'v'},
+      {"html_out", required_argument, nullptr, 'h'},
+      {nullptr, 0, nullptr, 0}};
   *api_endpoint = ASSISTANT_ENDPOINT;
   while (true) {
     int option_index;
@@ -140,17 +140,17 @@ bool GetCommandLineFlags(
 
 int main(int argc, char** argv) {
   std::string credentials_file_path, api_endpoint, locale, html_out_command;
-  #ifndef ENABLE_ALSA
-    std::cerr << "ALSA audio input is not supported on this platform."
-              << std::endl;
-    return -1;
-  #endif
+#ifndef ENABLE_ALSA
+  std::cerr << "ALSA audio input is not supported on this platform."
+            << std::endl;
+  return -1;
+#endif
 
   // Initialize gRPC and DNS resolvers
   // https://github.com/grpc/grpc/issues/11366#issuecomment-328595941
   grpc_init();
-  if (!GetCommandLineFlags(argc, argv, &credentials_file_path,
-                          &api_endpoint, &locale, &html_out_command)) {
+  if (!GetCommandLineFlags(argc, argv, &credentials_file_path, &api_endpoint,
+                           &locale, &html_out_command)) {
     return -1;
   }
 
@@ -160,7 +160,7 @@ int main(int argc, char** argv) {
     auto* assist_config = request.mutable_config();
 
     if (locale.empty()) {
-      locale = kLanguageCode; // Default locale
+      locale = kLanguageCode;  // Default locale
     }
     if (verbose) {
       std::clog << "Using locale " << locale << std::endl;
@@ -174,18 +174,18 @@ int main(int argc, char** argv) {
 
     // Set parameters for audio output
     assist_config->mutable_audio_out_config()->set_encoding(
-      AudioOutConfig::LINEAR16);
+        AudioOutConfig::LINEAR16);
     assist_config->mutable_audio_out_config()->set_sample_rate_hertz(16000);
 
     // Set parameters for screen config
     assist_config->mutable_screen_out_config()->set_screen_mode(
-      html_out_command.empty() ? ScreenOutConfig::SCREEN_MODE_UNSPECIFIED : ScreenOutConfig::PLAYING
-    );
+        html_out_command.empty() ? ScreenOutConfig::SCREEN_MODE_UNSPECIFIED
+                                 : ScreenOutConfig::PLAYING);
 
     std::unique_ptr<AudioInput> audio_input;
     // Set the AudioInConfig of the AssistRequest
     assist_config->mutable_audio_in_config()->set_encoding(
-      AudioInConfig::LINEAR16);
+        AudioInConfig::LINEAR16);
     assist_config->mutable_audio_in_config()->set_sample_rate_hertz(16000);
 
     // Read credentials file.
@@ -216,8 +216,8 @@ int main(int argc, char** argv) {
     context.set_fail_fast(false);
     context.set_credentials(call_credentials);
 
-    std::shared_ptr<ClientReaderWriter<AssistRequest, AssistResponse>>
-        stream(std::move(assistant->Assist(&context)));
+    std::shared_ptr<ClientReaderWriter<AssistRequest, AssistResponse>> stream(
+        std::move(assistant->Assist(&context)));
     // Write config in first stream.
     if (verbose) {
       std::clog << "assistant_sdk wrote first request: "
@@ -225,17 +225,15 @@ int main(int argc, char** argv) {
     }
     stream->Write(request);
 
-      audio_input.reset(new AudioInputALSA());
+    audio_input.reset(new AudioInputALSA());
 
-      audio_input->AddDataListener(
+    audio_input->AddDataListener(
         [stream, &request](std::shared_ptr<std::vector<unsigned char>> data) {
           request.set_audio_in(&((*data)[0]), data->size());
           stream->Write(request);
-      });
-      audio_input->AddStopListener([stream]() {
-        stream->WritesDone();
-      });
-      audio_input->Start();
+        });
+    audio_input->AddStopListener([stream]() { stream->WritesDone(); });
+    audio_input->Start();
 
     AudioOutputALSA audio_output;
     audio_output.Start();
@@ -256,13 +254,12 @@ int main(int argc, char** argv) {
       if (response.has_audio_out()) {
         // CUSTOMIZE: play back audio_out here.
 
-        std::shared_ptr<std::vector<unsigned char>>
-            data(new std::vector<unsigned char>);
+        std::shared_ptr<std::vector<unsigned char>> data(
+            new std::vector<unsigned char>);
         data->resize(response.audio_out().audio_data().length());
         memcpy(&((*data)[0]), response.audio_out().audio_data().c_str(),
-            response.audio_out().audio_data().length());
+               response.audio_out().audio_data().length());
         audio_output.Send(data);
-
       }
       // CUSTOMIZE: render spoken request on screen
       for (int i = 0; i < response.speech_results_size(); i++) {
@@ -271,15 +268,19 @@ int main(int argc, char** argv) {
         if (verbose) {
           std::clog << "assistant_sdk request: \n"
                     << result.transcript() << " ("
-                    << std::to_string(result.stability())
-                    << ")" << std::endl;
+                    << std::to_string(result.stability()) << ")" << std::endl;
         }
       }
-      if (!html_out_command.empty() && response.screen_out().data().size() > 0) {
-        std::string html_out_base64 = base64_encode(response.screen_out().data());
-        system((html_out_command + " \"data:text/html;base64, " + html_out_base64 + "\"").c_str());
+      if (!html_out_command.empty() &&
+          response.screen_out().data().size() > 0) {
+        std::string html_out_base64 =
+            base64_encode(response.screen_out().data());
+        system((html_out_command + " \"data:text/html;base64, " +
+                html_out_base64 + "\"")
+                   .c_str());
       } else if (html_out_command.empty()) {
-        if (response.dialog_state_out().supplemental_display_text().size() > 0) {
+        if (response.dialog_state_out().supplemental_display_text().size() >
+            0) {
           // CUSTOMIZE: render spoken response on screen
           std::clog << "assistant_sdk response:" << std::endl;
           std::cout << response.dialog_state_out().supplemental_display_text()
@@ -288,15 +289,13 @@ int main(int argc, char** argv) {
       }
     }
 
-
     audio_output.Stop();
-
 
     grpc::Status status = stream->Finish();
     if (!status.ok()) {
       // Report the RPC failure.
-      std::cerr << "assistant_sdk failed, error: " <<
-                status.error_message() << std::endl;
+      std::cerr << "assistant_sdk failed, error: " << status.error_message()
+                << std::endl;
       return -1;
     }
   }

--- a/src/run_assistant_audio.cc
+++ b/src/run_assistant_audio.cc
@@ -44,14 +44,15 @@ limitations under the License.
 #include "base64_encode.h"
 #include "json_util.h"
 
-using google::assistant::embedded::v1alpha2::AssistRequest;
-using google::assistant::embedded::v1alpha2::AssistResponse;
-using google::assistant::embedded::v1alpha2::
-    AssistResponse_EventType_END_OF_UTTERANCE;
-using google::assistant::embedded::v1alpha2::AudioInConfig;
-using google::assistant::embedded::v1alpha2::AudioOutConfig;
-using google::assistant::embedded::v1alpha2::EmbeddedAssistant;
-using google::assistant::embedded::v1alpha2::ScreenOutConfig;
+namespace assistant = google::assistant::embedded::v1alpha2;
+
+using assistant::AssistRequest;
+using assistant::AssistResponse;
+using assistant::AssistResponse_EventType_END_OF_UTTERANCE;
+using assistant::AudioInConfig;
+using assistant::AudioOutConfig;
+using assistant::EmbeddedAssistant;
+using assistant::ScreenOutConfig;
 
 using grpc::CallCredentials;
 using grpc::Channel;
@@ -263,8 +264,7 @@ int main(int argc, char** argv) {
       }
       // CUSTOMIZE: render spoken request on screen
       for (int i = 0; i < response.speech_results_size(); i++) {
-        google::assistant::embedded::v1alpha2::SpeechRecognitionResult result =
-            response.speech_results(i);
+        auto result = response.speech_results(i);
         if (verbose) {
           std::clog << "assistant_sdk request: \n"
                     << result.transcript() << " ("

--- a/src/run_assistant_file.cc
+++ b/src/run_assistant_file.cc
@@ -35,13 +35,14 @@ limitations under the License.
 #include "base64_encode.h"
 #include "json_util.h"
 
-using google::assistant::embedded::v1alpha2::AssistRequest;
-using google::assistant::embedded::v1alpha2::AssistResponse;
-using google::assistant::embedded::v1alpha2::
-    AssistResponse_EventType_END_OF_UTTERANCE;
-using google::assistant::embedded::v1alpha2::AudioInConfig;
-using google::assistant::embedded::v1alpha2::AudioOutConfig;
-using google::assistant::embedded::v1alpha2::EmbeddedAssistant;
+namespace assistant = google::assistant::embedded::v1alpha2;
+
+using assistant::AssistRequest;
+using assistant::AssistResponse;
+using assistant::AssistResponse_EventType_END_OF_UTTERANCE;
+using assistant::AudioInConfig;
+using assistant::AudioOutConfig;
+using assistant::EmbeddedAssistant;
 
 using grpc::CallCredentials;
 using grpc::Channel;
@@ -269,8 +270,7 @@ int main(int argc, char** argv) {
     }
     // CUSTOMIZE: render spoken request on screen
     for (int i = 0; i < response.speech_results_size(); i++) {
-      google::assistant::embedded::v1alpha2::SpeechRecognitionResult result =
-          response.speech_results(i);
+      auto result = response.speech_results(i);
       if (verbose) {
         std::clog << "assistant_sdk request: \n"
                   << result.transcript() << " ("

--- a/src/run_assistant_text.cc
+++ b/src/run_assistant_text.cc
@@ -22,14 +22,12 @@ limitations under the License.
 #include <fstream>
 #include <iostream>
 #include <iterator>
+#include <sstream>
 #include <string>
 #include <thread>
-#include <iostream>
-#include <fstream>
-#include <sstream>
 
-#include "google/assistant/embedded/v1alpha2/embedded_assistant.pb.h"
 #include "google/assistant/embedded/v1alpha2/embedded_assistant.grpc.pb.h"
+#include "google/assistant/embedded/v1alpha2/embedded_assistant.pb.h"
 
 #include "assistant_config.h"
 #include "audio_input.h"
@@ -37,13 +35,14 @@ limitations under the License.
 #include "base64_encode.h"
 #include "json_util.h"
 
-using google::assistant::embedded::v1alpha2::EmbeddedAssistant;
 using google::assistant::embedded::v1alpha2::AssistRequest;
 using google::assistant::embedded::v1alpha2::AssistResponse;
+using google::assistant::embedded::v1alpha2::
+    AssistResponse_EventType_END_OF_UTTERANCE;
 using google::assistant::embedded::v1alpha2::AudioInConfig;
 using google::assistant::embedded::v1alpha2::AudioOutConfig;
+using google::assistant::embedded::v1alpha2::EmbeddedAssistant;
 using google::assistant::embedded::v1alpha2::ScreenOutConfig;
-using google::assistant::embedded::v1alpha2::AssistResponse_EventType_END_OF_UTTERANCE;
 
 using grpc::CallCredentials;
 using grpc::Channel;
@@ -70,8 +69,9 @@ std::shared_ptr<Channel> CreateChannel(const std::string& host) {
   auto creds = ::grpc::SslCredentials(ssl_opts);
   std::string server = host + ":443";
   if (verbose) {
-    std::clog << "assistant_sdk CreateCustomChannel(" << server << ", creds, arg)"
-      << std::endl << std::endl;
+    std::clog << "assistant_sdk CreateCustomChannel(" << server
+              << ", creds, arg)" << std::endl
+              << std::endl;
   }
   ::grpc::ChannelArguments channel_args;
   return CreateCustomChannel(server, creds, channel_args);
@@ -82,21 +82,20 @@ void PrintUsage() {
             << "--credentials <credentials_file> "
             << "[--api_endpoint <API endpoint>] "
             << "[--locale <locale>]"
-            << "[--html_out <command to load HTML file>]"
-            << std::endl;
+            << "[--html_out <command to load HTML file>]" << std::endl;
 }
 
-bool GetCommandLineFlags(
-    int argc, char** argv, std::string* credentials_file_path,
-    std::string* api_endpoint, std::string* locale, std::string* html_out_command) {
+bool GetCommandLineFlags(int argc, char** argv,
+                         std::string* credentials_file_path,
+                         std::string* api_endpoint, std::string* locale,
+                         std::string* html_out_command) {
   const struct option long_options[] = {
-    {"credentials", required_argument, nullptr, 'c'},
-    {"api_endpoint",     required_argument, nullptr, 'e'},
-    {"locale",           required_argument, nullptr, 'l'},
-    {"verbose",          no_argument, nullptr, 'v'},
-    {"html_out",         required_argument, nullptr, 'h'},
-    {nullptr, 0, nullptr, 0}
-  };
+      {"credentials", required_argument, nullptr, 'c'},
+      {"api_endpoint", required_argument, nullptr, 'e'},
+      {"locale", required_argument, nullptr, 'l'},
+      {"verbose", no_argument, nullptr, 'v'},
+      {"html_out", required_argument, nullptr, 'h'},
+      {nullptr, 0, nullptr, 0}};
   *api_endpoint = ASSISTANT_ENDPOINT;
   while (true) {
     int option_index;
@@ -130,12 +129,13 @@ bool GetCommandLineFlags(
 }
 
 int main(int argc, char** argv) {
-  std::string credentials_file_path, api_endpoint, locale, text_input_source, html_out_command;
+  std::string credentials_file_path, api_endpoint, locale, text_input_source,
+      html_out_command;
   // Initialize gRPC and DNS resolvers
   // https://github.com/grpc/grpc/issues/11366#issuecomment-328595941
   grpc_init();
-  if (!GetCommandLineFlags(argc, argv, &credentials_file_path,
-                          &api_endpoint, &locale, &html_out_command)) {
+  if (!GetCommandLineFlags(argc, argv, &credentials_file_path, &api_endpoint,
+                           &locale, &html_out_command)) {
     return -1;
   }
 
@@ -145,7 +145,7 @@ int main(int argc, char** argv) {
     auto* assist_config = request.mutable_config();
 
     if (locale.empty()) {
-      locale = kLanguageCode; // Default locale
+      locale = kLanguageCode;  // Default locale
     }
     if (verbose) {
       std::clog << "Using locale " << locale << std::endl;
@@ -159,14 +159,14 @@ int main(int argc, char** argv) {
 
     // Set parameters for audio output
     assist_config->mutable_audio_out_config()->set_encoding(
-      AudioOutConfig::LINEAR16);
+        AudioOutConfig::LINEAR16);
     assist_config->mutable_audio_out_config()->set_sample_rate_hertz(16000);
     assist_config->set_text_query(text_input_source);
 
     // Set parameters for screen config
     assist_config->mutable_screen_out_config()->set_screen_mode(
-      html_out_command.empty() ? ScreenOutConfig::SCREEN_MODE_UNSPECIFIED : ScreenOutConfig::PLAYING
-    );
+        html_out_command.empty() ? ScreenOutConfig::SCREEN_MODE_UNSPECIFIED
+                                 : ScreenOutConfig::PLAYING);
 
     // Read credentials file.
     std::ifstream credentials_file(credentials_file_path);
@@ -196,8 +196,8 @@ int main(int argc, char** argv) {
     context.set_fail_fast(false);
     context.set_credentials(call_credentials);
 
-    std::shared_ptr<ClientReaderWriter<AssistRequest, AssistResponse>>
-        stream(std::move(assistant->Assist(&context)));
+    std::shared_ptr<ClientReaderWriter<AssistRequest, AssistResponse>> stream(
+        std::move(assistant->Assist(&context)));
     // Write config in first stream.
     if (verbose) {
       std::clog << "assistant_sdk wrote first request: "
@@ -218,15 +218,19 @@ int main(int argc, char** argv) {
         if (verbose) {
           std::clog << "assistant_sdk request: \n"
                     << result.transcript() << " ("
-                    << std::to_string(result.stability())
-                    << ")" << std::endl;
+                    << std::to_string(result.stability()) << ")" << std::endl;
         }
       }
-      if (!html_out_command.empty() && response.screen_out().data().size() > 0) {
-        std::string html_out_base64 = base64_encode(response.screen_out().data());
-        system((html_out_command + " \"data:text/html;base64, " + html_out_base64 + "\"").c_str());
+      if (!html_out_command.empty() &&
+          response.screen_out().data().size() > 0) {
+        std::string html_out_base64 =
+            base64_encode(response.screen_out().data());
+        system((html_out_command + " \"data:text/html;base64, " +
+                html_out_base64 + "\"")
+                   .c_str());
       } else if (html_out_command.empty()) {
-        if (response.dialog_state_out().supplemental_display_text().size() > 0) {
+        if (response.dialog_state_out().supplemental_display_text().size() >
+            0) {
           // CUSTOMIZE: render spoken response on screen
           std::clog << "assistant_sdk response:" << std::endl;
           std::cout << response.dialog_state_out().supplemental_display_text()
@@ -238,8 +242,8 @@ int main(int argc, char** argv) {
     grpc::Status status = stream->Finish();
     if (!status.ok()) {
       // Report the RPC failure.
-      std::cerr << "assistant_sdk failed, error: " <<
-                status.error_message() << std::endl;
+      std::cerr << "assistant_sdk failed, error: " << status.error_message()
+                << std::endl;
       return -1;
     }
   }

--- a/src/run_assistant_text.cc
+++ b/src/run_assistant_text.cc
@@ -35,14 +35,15 @@ limitations under the License.
 #include "base64_encode.h"
 #include "json_util.h"
 
-using google::assistant::embedded::v1alpha2::AssistRequest;
-using google::assistant::embedded::v1alpha2::AssistResponse;
-using google::assistant::embedded::v1alpha2::
-    AssistResponse_EventType_END_OF_UTTERANCE;
-using google::assistant::embedded::v1alpha2::AudioInConfig;
-using google::assistant::embedded::v1alpha2::AudioOutConfig;
-using google::assistant::embedded::v1alpha2::EmbeddedAssistant;
-using google::assistant::embedded::v1alpha2::ScreenOutConfig;
+namespace assistant = google::assistant::embedded::v1alpha2;
+
+using assistant::AssistRequest;
+using assistant::AssistResponse;
+using assistant::AssistResponse_EventType_END_OF_UTTERANCE;
+using assistant::AudioInConfig;
+using assistant::AudioOutConfig;
+using assistant::EmbeddedAssistant;
+using assistant::ScreenOutConfig;
 
 using grpc::CallCredentials;
 using grpc::Channel;
@@ -213,8 +214,7 @@ int main(int argc, char** argv) {
     while (stream->Read(&response)) {  // Returns false when no more to read.
       // CUSTOMIZE: render spoken request on screen
       for (int i = 0; i < response.speech_results_size(); i++) {
-        google::assistant::embedded::v1alpha2::SpeechRecognitionResult result =
-            response.speech_results(i);
+        auto result = response.speech_results(i);
         if (verbose) {
           std::clog << "assistant_sdk request: \n"
                     << result.transcript() << " ("

--- a/src/scope_exit.h
+++ b/src/scope_exit.h
@@ -21,7 +21,7 @@ limitations under the License.
 
 class ScopeExit {
  public:
-  ScopeExit(std::function<void()> f): f_(f) {}
+  ScopeExit(std::function<void()> f) : f_(f) {}
   ~ScopeExit() { f_(); }
 
  private:


### PR DESCRIPTION
At the moment this project is lacking any .clang-format configuration. This PR adds one based on the Google's style. It makes working with editor supporting clang-format e.g. VS Code or VS 2017 a better experience.
