### PR TITLE
Cleanup shell scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,37 +52,31 @@ cd third_party/protobuf
 sudo make install
 sudo ldconfig
 
-export LDFLAGS="$LDFLAGS -lm"
 cd ${GRPC_PATH}
 make clean
-make
+LDFLAGS="-lm" make
 sudo make install
 sudo ldconfig
 
 cd ${PROJECT_PATH}
 git clone https://github.com/googleapis/googleapis.git
 cd googleapis/
-make LANGUAGE=cpp
+GOOGLEAPIS_GENS_PATH=${PROJECT_PATH}/googleapis/gens make LANGUAGE=cpp
 ```
 
-4. Make sure you setup environment variable `$GOOGLEAPIS_GENS_PATH`
-```
-export GOOGLEAPIS_GENS_PATH=${PROJECT_PATH}/googleapis/gens
-```
-
-5. Build this project
+4. Build this project
 ```
 cd ${PROJECT_PATH}
 make run_assistant
 ```
 
-6. Get credentials file. It must be an end-user's credentials.
+5. Get credentials file. It must be an end-user's credentials.
 
 * Go to the [Actions Console](https://console.actions.google.com/) and register your device model, following [these instructions](https://developers.google.com/assistant/sdk/guides/library/python/embed/register-device)
 * Move it in this folder and rename it to `client_secret.json`
 * run `get_credentials.sh` in this folder. It will create the file `credentials.json`.
 
-7. Start one of the `run_assistant` samples:
+6. Start one of the `run_assistant` samples:
 
 ```bash
 ./run_assistant_file --input ./resources/weather_in_mountain_view.raw --output ./response.wav --credentials ./credentials.json

--- a/tests/build.sh
+++ b/tests/build.sh
@@ -20,7 +20,7 @@ git clone -b "$(curl -L https://grpc.io/release)" https://github.com/grpc/grpc
 GRPC_PATH=${PROJECT_PATH}/grpc
 cd "${GRPC_PATH}"
 # Checkout stable release of gRPC
-git checkout v1.11.0
+git checkout v1.16.0
 git submodule update --init
 
 echo "Compiling gRPC protobufs"

--- a/tests/clean-all.sh
+++ b/tests/clean-all.sh
@@ -1,7 +1,13 @@
+#!/bin/bash
+set -e
+set -u
+set -o pipefail
+set -x
+
 # Greedily cleans the project and system-wide dependencies
 # This will put the development machine in a clean state
 # to install development tools.
-rm -f *.o run_assistant googleapis.ar ./src/*.o
+git clean -xfd -e *.json
 rm -rf ./grpc/ ./googleapis/
 # https://github.com/grpc/grpc/pull/10706#issuecomment-302775038
 sudo apt-get purge -y libc-ares-dev

--- a/tests/integration_audio_file.sh
+++ b/tests/integration_audio_file.sh
@@ -1,9 +1,12 @@
+#!/bin/bash
+set -e
+set -u
+set -o pipefail
+set -x
+
 # Tests that the command "weather in mountain view"
 #   will return some data including the name of the town
 #   to verify the Assistant SDK end-to-end.
-set -e
-set -x
-
 ./run_assistant_file --input ./resources/weather_in_mountain_view.raw \
   --output /tmp/google-assistant-sdk-audio-output.raw \
   --credentials ./credentials.json \

--- a/tests/integration_en_us.sh
+++ b/tests/integration_en_us.sh
@@ -4,8 +4,8 @@ set -u
 set -o pipefail
 set -x
 
-# Tests that the command "how do you say hi in spanish"
+# Tests that the command "How do you say hi in spanish?"
 #   will return "Hola" to verify the Assistant SDK
 #   end-to-end.
-echo "how do you say hi in spanish" | ./run_assistant_text \
+echo "How do you say hi in spanish?" | ./run_assistant_text \
   --credentials ./credentials.json --verbose | grep "Hola"

--- a/tests/integration_en_us.sh
+++ b/tests/integration_en_us.sh
@@ -1,8 +1,11 @@
+#!/bin/bash
+set -e
+set -u
+set -o pipefail
+set -x
+
 # Tests that the command "how do you say hi in spanish"
 #   will return "Hola" to verify the Assistant SDK
 #   end-to-end.
-set -e
-set -x
-
 echo "how do you say hi in spanish" | ./run_assistant_text \
   --credentials ./credentials.json --verbose | grep "Hola"

--- a/tests/integration_fr.sh
+++ b/tests/integration_fr.sh
@@ -1,9 +1,12 @@
+#!/bin/bash
+set -e
+set -u
+set -o pipefail
+set -x
+
 # Tests that the command "how do you say hello in spanish"
 #   will return "buenos dias" to verify the Assistant SDK
 #   end-to-end.
-set -e
-set -x
-
 echo "comment dit-on bonjour en español" | ./run_assistant_text \
   --credentials ./credentials.json \
   --locale "fr-FR" --verbose | grep "Buenos dias"

--- a/tests/integration_fr.sh
+++ b/tests/integration_fr.sh
@@ -4,9 +4,9 @@ set -u
 set -o pipefail
 set -x
 
-# Tests that the command "how do you say hello in spanish"
-#   will return "buenos dias" to verify the Assistant SDK
+# Tests that the command "How do you say hello in spanish?"
+#   will return "Buenos dias" to verify the Assistant SDK
 #   end-to-end.
-echo "comment dit-on bonjour en español" | ./run_assistant_text \
+echo "Comment dit-on bonjour en espagnol?" | ./run_assistant_text \
   --credentials ./credentials.json \
   --locale "fr-FR" --verbose | grep "Buenos dias"

--- a/tests/test_all.sh
+++ b/tests/test_all.sh
@@ -1,8 +1,12 @@
+#!/bin/bash
+set -e
+set -u
+set -o pipefail
+set -x
+
 # Run all tests
 # Expected usage:
 #   > cpp$ ./tests/test_all.sh
-set -e
-set -x
 
 # Verify it builds
 ./tests/build.sh


### PR DESCRIPTION
- apply shellcheck and use Bash strict mode.
- use the same prolog in each shell script.
- avoid exporting variables when not needed.
- take advantage of git clean to cleanup.
- be less verbose with apt-get install.
- upgrade to gRPC v1.16.0 to address issue #35. 
- fix language spelling.
