### PR TITLE
Simplify some C++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,9 @@ endif
 
 CPPFLAGS += -I$(GOOGLEAPIS_GENS_PATH) \
             -I$(GRPC_SRC_PATH) \
-            -I./src
+            -I./src \
+            -Wall \
+            -Wextra
 
 CXXFLAGS += -std=c++11 $(GRPC_GRPCPP_CFLAGS)
 

--- a/src/assistant/audio_input.h
+++ b/src/assistant/audio_input.h
@@ -55,7 +55,7 @@ class AudioInput {
       return;
     }
 
-    send_thread_ = std::move(GetBackgroundThread());
+    send_thread_ = GetBackgroundThread();
     is_running_ = true;
     return;
   }

--- a/src/assistant/audio_input_alsa.cc
+++ b/src/assistant/audio_input_alsa.cc
@@ -91,10 +91,10 @@ std::unique_ptr<std::thread> AudioInputALSA::GetBackgroundThread() {
     snd_pcm_hw_params_free(pcm_params);
 
     while (is_running_) {
-      std::shared_ptr<std::vector<unsigned char>> audio_data(
-          new std::vector<unsigned char>(kFramesPerPacket * kBytesPerFrame));
+      auto audio_data = std::make_shared<std::vector<unsigned char>>(
+          kFramesPerPacket * kBytesPerFrame);
       int pcm_read_ret =
-          snd_pcm_readi(pcm_handle, &(*audio_data.get())[0], kFramesPerPacket);
+          snd_pcm_readi(pcm_handle, audio_data->data(), kFramesPerPacket);
       if (pcm_read_ret == -EAGAIN) {
         std::this_thread::sleep_for(std::chrono::milliseconds(20));
       } else if (pcm_read_ret < 0) {

--- a/src/assistant/audio_output_alsa.h
+++ b/src/assistant/audio_output_alsa.h
@@ -38,9 +38,9 @@ class AudioOutputALSA {
   std::vector<std::shared_ptr<std::vector<unsigned char>>> audioData;
   std::mutex audioDataMutex;
   std::condition_variable audioDataCv;
-  std::unique_ptr<std::thread> alsaThread;
   bool isRunning = false;
   std::mutex isRunningMutex;
+  std::thread alsaThread;
 };
 
 #endif  // SRC_ASSISTANT_AUDIO_OUTPUT_ALSA_H_

--- a/src/assistant/base64_encode.cc
+++ b/src/assistant/base64_encode.cc
@@ -24,7 +24,7 @@ std::string base64_encode(const std::string &in) {
   unsigned val = 0;
   int valb = -6;
 
-  for (u_char c : in) {
+  for (unsigned char c : in) {
     val = (val << 8) + c;
     valb += 8;
     while (valb >= 0) {

--- a/src/assistant/json_util_test.cc
+++ b/src/assistant/json_util_test.cc
@@ -36,7 +36,7 @@ int main() {
   }
 
   std::string incomplete_json = "{}";
-  intended_result.reset(nullptr);
+  intended_result = nullptr;
   if (!check_result(incomplete_json, std::move(intended_result))) {
     std::cerr << "Test failed for incomplete JSON" << std::endl;
     return 1;

--- a/src/assistant/run_assistant_audio.cc
+++ b/src/assistant/run_assistant_audio.cc
@@ -183,7 +183,6 @@ int main(int argc, char** argv) {
         html_out_command.empty() ? ScreenOutConfig::SCREEN_MODE_UNSPECIFIED
                                  : ScreenOutConfig::PLAYING);
 
-    std::unique_ptr<AudioInput> audio_input;
     // Set the AudioInConfig of the AssistRequest
     assist_config->mutable_audio_in_config()->set_encoding(
         AudioInConfig::LINEAR16);
@@ -201,7 +200,7 @@ int main(int argc, char** argv) {
     std::string credentials = credentials_buffer.str();
     std::shared_ptr<CallCredentials> call_credentials;
     call_credentials = grpc::GoogleRefreshTokenCredentials(credentials);
-    if (call_credentials.get() == nullptr) {
+    if (call_credentials == nullptr) {
       std::cerr << "Credentials file \"" << credentials_file_path
                 << "\" is invalid. Check step 5 in README for how to get valid "
                 << "credentials." << std::endl;
@@ -217,8 +216,8 @@ int main(int argc, char** argv) {
     context.set_fail_fast(false);
     context.set_credentials(call_credentials);
 
-    std::shared_ptr<ClientReaderWriter<AssistRequest, AssistResponse>> stream(
-        std::move(assistant->Assist(&context)));
+    using AssistantClient = ClientReaderWriter<AssistRequest, AssistResponse>;
+    std::shared_ptr<AssistantClient> stream = assistant->Assist(&context);
     // Write config in first stream.
     if (verbose) {
       std::clog << "assistant_sdk wrote first request: "
@@ -226,8 +225,7 @@ int main(int argc, char** argv) {
     }
     stream->Write(request);
 
-    audio_input.reset(new AudioInputALSA());
-
+    std::unique_ptr<AudioInput> audio_input(new AudioInputALSA());
     audio_input->AddDataListener(
         [stream, &request](std::shared_ptr<std::vector<unsigned char>> data) {
           request.set_audio_in(&((*data)[0]), data->size());
@@ -255,8 +253,7 @@ int main(int argc, char** argv) {
       if (response.has_audio_out()) {
         // CUSTOMIZE: play back audio_out here.
 
-        std::shared_ptr<std::vector<unsigned char>> data(
-            new std::vector<unsigned char>);
+        auto data = std::make_shared<std::vector<unsigned char>>();
         data->resize(response.audio_out().audio_data().length());
         memcpy(&((*data)[0]), response.audio_out().audio_data().c_str(),
                response.audio_out().audio_data().length());

--- a/src/assistant/run_assistant_text.cc
+++ b/src/assistant/run_assistant_text.cc
@@ -181,7 +181,7 @@ int main(int argc, char** argv) {
     std::string credentials = credentials_buffer.str();
     std::shared_ptr<CallCredentials> call_credentials;
     call_credentials = grpc::GoogleRefreshTokenCredentials(credentials);
-    if (call_credentials.get() == nullptr) {
+    if (call_credentials == nullptr) {
       std::cerr << "Credentials file \"" << credentials_file_path
                 << "\" is invalid. Check step 5 in README for how to get valid "
                 << "credentials." << std::endl;
@@ -197,8 +197,8 @@ int main(int argc, char** argv) {
     context.set_fail_fast(false);
     context.set_credentials(call_credentials);
 
-    std::shared_ptr<ClientReaderWriter<AssistRequest, AssistResponse>> stream(
-        std::move(assistant->Assist(&context)));
+    using AssistantClient = ClientReaderWriter<AssistRequest, AssistResponse>;
+    std::shared_ptr<AssistantClient> stream = assistant->Assist(&context);
     // Write config in first stream.
     if (verbose) {
       std::clog << "assistant_sdk wrote first request: "


### PR DESCRIPTION
- Enable warnings when compiling.
-  Read and send 16kB when using files. #48 
    - change chunk_size and the delay accordingly
    - use std::make_shared to avoid calling new
    - use std::vector::data to access the underlying array
- u_char is not a standard type. #52
-  Simplify smart pointers use.
    - prefer using std::make_shared when possible
    - use std::vector::data to access the underlying array
    - no need to call .get() on a smart pointer when comparing to nullptr
    - avoid using std::move when not required
    - use type aliasing to improve readability
    - avoid calling std::unique_ptr::reset when not needed
    - audio_output_alsa.cc: no need to put std::thread in a std::unique_ptr