### PR TITLE
build grpc v1.32.0 using cmake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,15 +57,19 @@ CPPFLAGS += -I$(GOOGLEAPIS_GENS_PATH) \
 
 CXXFLAGS += -std=c++11 $(GRPC_GRPCPP_CFLAGS)
 
-# grpc_cronet is for JSON functions in gRPC library.
 ifeq ($(SYSTEM),Darwin)
 LDFLAGS += $(GRPC_GRPCPP_LDLAGS) \
-           -lgrpc++_reflection -lgrpc_cronet \
+           -lgrpc++_reflection \
            -lprotobuf -lpthread -ldl
 else
 LDFLAGS += $(GRPC_GRPCPP_LDLAGS) \
-           -lgrpc_cronet -Wl,--no-as-needed -lgrpc++_reflection \
+           -Wl,--no-as-needed -lgrpc++_reflection \
            -Wl,--as-needed -lprotobuf -lpthread -ldl
+endif
+
+HAS_LIB_ATOMIC ?= $(shell ldconfig -p | grep libatomic >/dev/null >&1 && echo true || echo false)
+ifeq ($(HAS_LIB_ATOMIC),true)
+LDFLAGS += -latomic
 endif
 
 AUDIO_SRCS =
@@ -75,7 +79,7 @@ CXXFLAGS += $(ALSA_CFLAGS)
 LDFLAGS += $(ALSA_LDFLAGS)
 endif
 
-CORE_SRCS = ./src/assistant/base64_encode.cc ./src/assistant/json_util.cc
+CORE_SRCS = ./src/assistant/base64_encode.cc
 AUDIO_INPUT_FILE_SRCS = ./src/assistant/audio_input_file.cc
 ASSISTANT_AUDIO_SRCS = ./src/assistant/run_assistant_audio.cc
 ASSISTANT_FILE_SRCS = ./src/assistant/run_assistant_file.cc

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Refer to the [Assistant SDK documentation](https://developers.google.com/assista
 
 _If you have not setup this project before, you can skip this step._
 
-```
+```bash
 sudo apt-get purge libc-ares-dev  # https://github.com/grpc/grpc/pull/10706#issuecomment-302775038
 sudo apt-get purge libprotobuf-dev libprotoc-dev
 sudo rm -rf /usr/local/bin/grpc_* /usr/local/bin/protoc \
     /usr/local/include/google/protobuf/ /usr/local/include/grpc/ /usr/local/include/grpc++/ \
-    /usr/local/lib/libproto* /usr/local/lib/libgpr* /usr/local/lib/libgrpc* \
+    /usr/local/lib/libproto* /usr/local/lib/libgpr* /usr/local/lib/libgrpc* /usr/local/lib/libupb* \
     /usr/local/lib/pkgconfig/protobuf* /usr/local/lib/pkgconfig/grpc* \
     /usr/local/share/grpc/
 ```
@@ -26,95 +26,100 @@ sudo rm -rf /usr/local/bin/grpc_* /usr/local/bin/protoc \
 ### Build Project
 
 1. Clone this project
-```
-git clone https://github.com/googlesamples/assistant-sdk-cpp.git
-cd assistant-sdk-cpp
-export PROJECT_PATH=$(pwd)
-```
+
+    ```bash
+    git clone https://github.com/googlesamples/assistant-sdk-cpp.git
+    cd assistant-sdk-cpp
+    export PROJECT_PATH=$(pwd)
+    ```
 
 2. Install dependencies
-```
-sudo apt-get install autoconf automake libtool build-essential curl unzip pkg-config
-sudo apt-get install libasound2-dev  # For ALSA sound output
-sudo apt-get install libcurl4-openssl-dev # CURL development library
-```
+
+    ```bash
+    sudo apt-get install autoconf automake libtool build-essential curl unzip pkg-config
+    sudo apt-get install libasound2-dev  # For ALSA sound output
+    sudo apt-get install libcurl4-openssl-dev # CURL development library
+    sudo apt-get install -y cmake
+    sudo apt-get install -y libssl-dev
+    ```
 
 3. Build Protocol Buffer, gRPC, and Google APIs
-```
-git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
-GRPC_PATH=${PROJECT_PATH}/grpc
-cd ${GRPC_PATH}
 
-git submodule update --init
+    ```bash
+    git clone -b v1.30.2 https://github.com/grpc/grpc
+    GRPC_PATH=${PROJECT_PATH}/grpc
+    cd ${GRPC_PATH}
 
-cd third_party/protobuf
-./autogen.sh && ./configure && make
-sudo make install
-sudo ldconfig
+    git submodule update --init
 
-export LDFLAGS="$LDFLAGS -lm"
-cd ${GRPC_PATH}
-make clean
-make
-sudo make install
-sudo ldconfig
+    mkdir -p cmake/build
+    cd cmake/build
+    cmake -DgRPC_INSTALL=ON \
+        -DgRPC_BUILD_TESTS=OFF \
+        ../..
+    make -j
+    sudo make install
+    sudo ldconfig
 
-cd ${PROJECT_PATH}
-git clone https://github.com/googleapis/googleapis.git
-cd googleapis/
-git checkout 980cdfa
-make LANGUAGE=cpp
-```
+    cd ${PROJECT_PATH}
+    git clone https://github.com/googleapis/googleapis.git
+    cd googleapis/
+    git checkout 980cdfa
+    make LANGUAGE=cpp
+    ```
 
 4. Make sure you setup environment variable `$GOOGLEAPIS_GENS_PATH`
-```
-export GOOGLEAPIS_GENS_PATH=${PROJECT_PATH}/googleapis/gens
-```
+
+    ```bash
+    export GOOGLEAPIS_GENS_PATH=${PROJECT_PATH}/googleapis/gens
+    ```
 
 5. Build this project
-```
-cd ${PROJECT_PATH}
-make run_assistant
-```
+
+    ```bash
+    cd ${PROJECT_PATH}
+    make run_assistant
+    ```
 
 6. Get credentials file. It must be an end-user's credentials.
 
-* Go to the [Actions Console](https://console.actions.google.com/) and register your device model, following [these instructions](https://developers.google.com/assistant/sdk/guides/library/python/embed/register-device)
-* Move it in this folder and rename it to `client_secret.json`
-* run `get_credentials.sh` in this folder. It will create the file `credentials.json`.
+    * Go to [Google API Console](https://console.developers.google.com/apis/credentials) and request new *OAuth client ID* with application type of *TVs and Limited Input devices*, and download credentials file.
+
+    * Move it in this folder and rename it to `client_secret.json`
+    * run `get_credentials.sh` in this folder. It will create the file `credentials.json`.
 
 7. Start one of the `run_assistant` samples:
 
-```bash
-./run_assistant_file --input ./resources/weather_in_mountain_view.raw --output ./response.wav --credentials ./credentials.json
-aplay ./response.wav --rate=16000 --format=S16_LE
-```
+    ```bash
+    ./run_assistant_file --input ./resources/weather_in_mountain_view.raw --output ./response.wav --credentials ./credentials.json
+    aplay ./response.wav --rate=16000 --format=S16_LE
+    ```
 
-On a Linux workstation, you can alternatively use ALSA for audio input:
+    On a Linux workstation, you can alternatively use ALSA for audio input:
 
-```bash
-./run_assistant_audio --credentials ./credentials.json
-```
+    ```bash
+    ./run_assistant_audio --credentials ./credentials.json
+    ```
 
-You can use a text-based query instead of audio. This allows you to continually enter text queries to the Assistant.
+    You can use a text-based query instead of audio. This allows you to continually enter text queries to the Assistant.
 
-```bash
-./run_assistant_text --credentials ./credentials.json
-```
+    ```bash
+    ./run_assistant_text --credentials ./credentials.json
+    ```
 
-This takes input from `cin`, so you can send data to the program when it starts.
+    This takes input from `cin`, so you can send data to the program when it starts.
 
-```bash
-echo "what time is it" | ./run_assistant_text --credentials ./credentials.json
-```
+    ```bash
+    echo "what time is it" | ./run_assistant_text --credentials ./credentials.json
+    ```
 
-To change the locale, include a `locale` parameter:
+    To change the locale, include a `locale` parameter:
 
-```bash
-echo "Bonjour" | ./run_assistant_text --credentials ./credentials.json --locale "fr-FR"
-```
+    ```bash
+    echo "Bonjour" | ./run_assistant_text --credentials ./credentials.json --locale "fr-FR"
+    ```
 
-Default Assistant gRPC API endpoint is `embeddedassistant.googleapis.com`. If you want to test with a custom Assistant gRPC API endpoint, you can pass `--api_endpoint CUSTOM_API_ENDPOINT`.
+    Default Assistant gRPC API endpoint is `embeddedassistant.googleapis.com`. If you want to test with a custom Assistant gRPC API endpoint, you can pass `--api_endpoint CUSTOM_API_ENDPOINT`.
 
 ## Enabling screen output
 

--- a/tests/build.sh
+++ b/tests/build.sh
@@ -12,24 +12,25 @@ echo "Installing dependencies"
 sudo apt-get install -y autoconf automake libtool build-essential curl unzip pkg-config
 sudo apt-get install -y libasound2-dev  # For ALSA sound output
 sudo apt-get install -y libcurl4-openssl-dev # CURL development library
+sudo apt-get install -y cmake
+sudo apt-get install -y libssl-dev
 
 # Step 3. Build protocol buffer, gRPC, and Google APIs
 git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
 GRPC_PATH=${PROJECT_PATH}/grpc
 cd ${GRPC_PATH}
 # Checkout stable release of gRPC
-git checkout v1.11.0
+git checkout v1.32.0
 git submodule update --init
 
-echo "Compiling gRPC protobufs"
-cd third_party/protobuf
-./autogen.sh && ./configure && make
-sudo make install
-sudo ldconfig
-
 echo "Compiling gRPC"
-export LDFLAGS="$LDFLAGS -lm"
+# export LDFLAGS="$LDFLAGS -lm"
 cd ${GRPC_PATH}
+mkdir -p cmake/build
+cd cmake/build
+cmake -DgRPC_INSTALL=ON \
+      -DgRPC_BUILD_TESTS=OFF \
+      ../..
 make clean
 make
 sudo make install

--- a/tests/clean-all.sh
+++ b/tests/clean-all.sh
@@ -15,6 +15,7 @@ sudo rm -rf /usr/local/bin/grpc_* \
     /usr/local/lib/libproto* \
     /usr/local/lib/libgpr* \
     /usr/local/lib/libgrpc* \
+    /usr/local/lib/libupb* \
     /usr/local/lib/pkgconfig/protobuf* \
     /usr/local/lib/pkgconfig/grpc* \
     /usr/local/share/grpc/


### PR DESCRIPTION
This PR has changes to tests/build.sh to build tag v1.32.0 of gRPC, latest release at the moment, for Raspbian 10. I've tested it with a Raspberry Pi 3 Model B Rev 1.2. Changes were also made to Makefile to fix build errors, and the readme to aid those performing a manual build.